### PR TITLE
Make tests work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-readline",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "xterm-js readline addon",
   "keywords": [
     "xterm",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^5.46.1",
     "eslint": "^8.29.0",
     "jest": "^29.3.1",
+    "jest-environment-jsdom": "^29.3.1",
     "nodemon": "^2.0.20",
     "prettier": "^2.8.1",
     "ts-jest": "^29.0.3",
@@ -47,7 +48,7 @@
     "xterm": "^5.0.0"
   },
   "dependencies": {
-    "string-width": "^5.1.2"
+    "string-width": "^4.0.0"
   },
   "peerDependencies": {
     "xterm": "^5.0.0"


### PR DESCRIPTION
Rolled back string-width to 4.0.0, added jest-environment-jsdom, as it's not available by default.